### PR TITLE
Retweak user creation

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -17,4 +17,7 @@ class StaticPagesController < ApplicationController
 
   def contact
   end
+
+  def email_confirmation_sent
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,15 +33,13 @@ class UsersController < ApplicationController
       end
 
       respond_to do |format|
-        # TODO User needs to confirm email before login. It should redirect to an 
-        # email confirmaton was sent page.
         if !@user.new_record?
           # Tell the UserMailer to send a welcome Email after save
           flash[:success] = "Welcome to Worth Reading!"
-          sign_in @user
           UserMailer.welcome_email(@user).deliver
 
-          format.html { redirect_to(@user) }
+          # User needs to confirm email first before being able to sign in
+          format.html { redirect_to(email_confirmation_path) }
         else
           format.html { render action: "new" }
         end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
       # Checks if user already registered; i.e. User registered after sending an
       # email or User adds a subscriber who isn't a user thus creating a user for
       # that subscriber
-      if @user = User.find_by_email(params[:user][:email])
+      if @user = User.find_by_email(params[:user][:email]) and !@user.confirmed 
         @user.update_attributes(params[:user])
       else
         @user = User.new(params[:user])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,20 +21,29 @@ class UsersController < ApplicationController
     if signed_in?
       redirect_to home
     else
-      @user = User.new(params[:user])
+
+      # Checks if user already registered; i.e. User registered after sending an
+      # email or User adds a subscriber who isn't a user thus creating a user for
+      # that subscriber
+      if @user = User.find_by_email(params[:user][:email])
+        @user.update_attributes(params[:user])
+      else
+        @user = User.new(params[:user])
+        @user.save
+      end
 
       respond_to do |format|
-        if @user.save
+        # TODO User needs to confirm email before login. It should redirect to an 
+        # email confirmaton was sent page.
+        if !@user.new_record?
           # Tell the UserMailer to send a welcome Email after save
           flash[:success] = "Welcome to Worth Reading!"
           sign_in @user
           UserMailer.welcome_email(@user).deliver
 
           format.html { redirect_to(@user) }
-          format.json { render json: @user, status: :created, location: @user }
         else
           format.html { render action: "new" }
-          format.json { render json: @user.errors, status: :unprocessable_entity }
         end
       end
     end
@@ -96,12 +105,12 @@ class UsersController < ApplicationController
 
   private
 
-    def correct_user
-      @user = User.find(params[:id])
-      redirect_to(root_path) unless current_user?(@user)
-    end
-    
-    def admin_user
-      redirect_to(root_path) unless current_user.admin?
-    end
+  def correct_user
+    @user = User.find(params[:id])
+    redirect_to(root_path) unless current_user?(@user)
+  end
+
+  def admin_user
+    redirect_to(root_path) unless current_user.admin?
+  end
 end

--- a/app/views/static_pages/email_confirmation_sent.html.haml
+++ b/app/views/static_pages/email_confirmation_sent.html.haml
@@ -1,0 +1,7 @@
+- provide(:title, "Email Confirmation Sent")
+.row
+  .span8.offset2
+    .hero-unit
+      %p 
+        We just need you to confirm your email to ensure you actually own the 
+        email account specified before you can sign in.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ WorthReading::Application.routes.draw do
   match '/help',    to: 'static_pages#help'
   match '/about',   to: 'static_pages#about'
   match '/contact', to: 'static_pages#contact'
+  match '/email_confirmation', to: 'static_pages#email_confirmation_sent'
   
   match 'users/:id/confirm/:confirmation_token', 
     to: 'users#confirm_email', 

--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -87,16 +87,36 @@ describe "User pages" do
       end    end
 
     describe "with valid information" do
+      let(:name) { "Example User" }
+      let(:email) { "user@example.com" }
+      let(:password) { "foobar" }
       before do
-        fill_in "Name",         with: "Example User"
-        fill_in "Email",        with: "user@example.com"
-        fill_in "Password",     with: "foobar"
-        fill_in "Confirm Password", with: "foobar"
+        fill_in "Name",         with: name
+        fill_in "Email",        with: email
+        fill_in "Password",     with: password
+        fill_in "Confirm Password", with: password
       end
 
       it "should create a user" do
         expect { click_button submit }.to change(User, :count).by(1)
       end
+
+      context "when a user is already registered through some previous registration" do
+        before do 
+          @user = User.create(name: "No one", 
+                              email: "user@example.com", 
+                              password: "123456",
+                              password_confirmation: "123456")
+          click_button submit
+        end
+
+        it "should update the user attributes" do 
+          @user.reload.name.should  == name 
+          @user.reload.email.should == email 
+          @user.reload.authenticate(password).should be_true
+        end
+      end
+
       describe "after saving the user" do
         before { click_button submit }
         let(:user) { User.find_by_email('user@example.com') }
@@ -184,7 +204,7 @@ describe "User pages" do
 
     it "shouldn't confirm user with incorrect confirmation token" do
       visit confirm_email_path(id: user.id, confirmation_token: "132afsdljksfd;kj")
-      
+
       user.confirmed.should be_false
     end
   end

--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -101,20 +101,34 @@ describe "User pages" do
         expect { click_button submit }.to change(User, :count).by(1)
       end
 
-      context "when a user is already registered through some previous registration" do
+      describe "when a user is already registered through some previous registration" do
         before do 
           @user = User.create(name: "No one", 
                               email: "user@example.com", 
                               password: "123456",
                               password_confirmation: "123456")
-          click_button submit
         end
 
-        it "should update the user attributes" do 
-          @user.reload.name.should  == name 
-          @user.reload.email.should == email 
-          @user.reload.authenticate(password).should be_true
+        context "when user isn't confirmed" do
+          it "should update the user attributes" do 
+            click_button submit
+            @user.reload.name.should  == name 
+            @user.reload.email.should == email 
+            @user.reload.authenticate(password).should be_true
+          end
         end
+
+        context "when user is confirmed" do
+          before do 
+            @user.toggle!(:confirmed) 
+            @user.reload
+            click_button submit
+          end
+          it { should have_selector('title', text: 'Sign up') }
+          it { should have_content('error') }
+        end
+
+
       end
 
       describe "after saving the user" do

--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -121,9 +121,8 @@ describe "User pages" do
         before { click_button submit }
         let(:user) { User.find_by_email('user@example.com') }
 
-        it { should have_selector('title', text: user.name) }
+        it { should have_selector('title', text: "Email Confirmation Sent") }
         it { should have_selector('div.alert.alert-success', text: 'Welcome') }
-        it { should have_link('Sign out') }
       end
 
     end


### PR DESCRIPTION
I retweaked user creation.

There were several issues I was thinking about with the user creation:  
1. Say if I signed up with your email. You would not be able to sign up since your email was already taken. Thus, I set it up so that users can only sign in after confirming their email. So User sign up process is:  
a. User signs up and gets redirected to a page that asks for them to confirm email through email confirmation
b. User receives email and follows link to confirm email
c. User's email is confirmed and they can now sign in  
2. What if an email is already registered ( i.e. User 1 creates User 2 when he adds User 2 to his subscriber list. Thus, User 2 is already in the database.), so I checked if the email is in the database and if it was the parameters would be updated instead of a new user being created.  
3. But what if User 2 himself registers and someone else say Hacker 1 tries to register with User 2's email address after. Won't it update the attributes of User 2.  Thus, I checked if their email is confirmed. Only non-confirmed emails will have their parameters updated. Confirmed emails will return an error in the form stating that the email was already taken.
