### PR TITLE
Delayed jobs emailing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'haml-rails'
 
 # Backend Gems
 gem 'bcrypt-ruby', '3.0.1'
+gem 'delayed_job_active_record'
 gem 'thin' 
 
 # Bundle edge Rails instead:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,11 @@ GEM
       execjs
     coffee-script-source (1.3.3)
     daemons (1.1.8)
+    delayed_job (3.0.3)
+      activesupport (~> 3.0)
+    delayed_job_active_record (0.3.2)
+      activerecord (> 2.1.0)
+      delayed_job (~> 3.0.0)
     diff-lcs (1.1.3)
     erubis (2.7.0)
     eventmachine (0.12.10)
@@ -188,6 +193,7 @@ DEPENDENCIES
   bootstrap-will_paginate (= 0.0.6)
   capybara (= 1.1.2)
   coffee-rails (= 3.2.2)
+  delayed_job_active_record
   factory_girl_rails (= 1.4.0)
   faker (= 1.0.1)
   growl (= 1.0.3)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker:  bundle exec rake jobs:work

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -47,7 +47,7 @@ class EmailsController < ApplicationController
       wr_log_entry.save
 
       # TODO Uncomment once we can retrieve the correct email address to mail to.
-      # UserMailer.send_message(@email).deliver
+      # UserMailer.delay.send_message(@email)
     else
       redirect_to root_path  ## params['sender'] is bad 
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
         if !@user.new_record?
           # Tell the UserMailer to send a welcome Email after save
           flash[:success] = "Welcome to Worth Reading!"
-          UserMailer.welcome_email(@user).deliver
+          UserMailer.delay.welcome_email(@user)
 
           # User needs to confirm email first before being able to sign in
           format.html { redirect_to(email_confirmation_path) }

--- a/db/migrate/20120725205542_create_delayed_jobs.rb
+++ b/db/migrate/20120725205542_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, :force => true do |table|
+      table.integer  :priority, :default => 0      # Allows some jobs to jump to the front of the queue
+      table.integer  :attempts, :default => 0      # Provides for retries, but still fail eventually.
+      table.text     :handler                      # YAML-encoded string of the object that will do work
+      table.text     :last_error                   # reason for last failure (See Note below)
+      table.datetime :run_at                       # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                    # Set when a client is working on this object
+      table.datetime :failed_at                    # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string   :locked_by                    # Who is working on this object (if locked)
+      table.string   :queue                        # The name of the queue this job is in
+      table.timestamps
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], :name => 'delayed_jobs_priority'
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,23 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120719211513) do
+ActiveRecord::Schema.define(:version => 20120725205542) do
+
+  create_table "delayed_jobs", :force => true do |t|
+    t.integer  "priority",   :default => 0
+    t.integer  "attempts",   :default => 0
+    t.text     "handler"
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at",                :null => false
+    t.datetime "updated_at",                :null => false
+  end
+
+  add_index "delayed_jobs", ["priority", "run_at"], :name => "delayed_jobs_priority"
 
   create_table "emails", :force => true do |t|
     t.string   "from"

--- a/script/delayed_job
+++ b/script/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize


### PR DESCRIPTION
Emails are now sent as background process using a delayed_job. Delayed job uses background workers to execute tasks that take too long in the background by assigning a worker to it. In this case, I used delayed jobs for emails since creating and sending an email can tie up our processes preventing our server from receiving other HTTP requests.
